### PR TITLE
fix #4: hide tooltip info on disconnected screen

### DIFF
--- a/inst/assets/sever.js
+++ b/inst/assets/sever.js
@@ -18,7 +18,7 @@ function chg_default(bg_color, opacity, bg_image){
   if(bg_color == undefined)
     bg_color = "none";
 
-  css = "#shiny-disconnected-overlay{background-color: " + bg_color + "; opacity: " + opacity + "; background-size: cover; background-image: url('" + bg_image + "')}";
+  css = "#shiny-disconnected-overlay{background-color: " + bg_color + "; opacity: " + opacity + "; background-size: cover; background-image: url('" + bg_image + "'); z-index: 99999998}";
 
   head.appendChild(style);
 


### PR DESCRIPTION
Close #4, the tooltip is no longer displayed on disconnected screen.

One remaining issue is that the pointer is a hand (as if we could click something). I tried to remove it with `cursor: default;` or `pointer-events: initial;` but no success.