### PR TITLE
Add an observable input

### DIFF
--- a/R/rupture.R
+++ b/R/rupture.R
@@ -37,7 +37,8 @@
 #' @export
 rupture <- function(html = rupture_default(), color = "#fff", opacity = 1, 
   bg_color = "#333e48", bg_image = NULL, ms = 1000 * 60 * 15,
-  session = shiny::getDefaultReactiveDomain(), box = FALSE){
+  session = shiny::getDefaultReactiveDomain(), box = FALSE, 
+  callback_name="ruptured"){
 
   html <- as.character(html)
   msg <- list(
@@ -47,7 +48,8 @@ rupture <- function(html = rupture_default(), color = "#fff", opacity = 1,
     opacity = opacity,
     bg_image = bg_image,
     box = box,
-    ms = ms
+    ms = ms,
+    callback_name = callback_name
   )
 
   session$sendCustomMessage("rupture-it", msg)

--- a/inst/assets/rupture.js
+++ b/inst/assets/rupture.js
@@ -9,7 +9,7 @@ function watchActivity(opts) {
 
   function logout() {
     rupture(opts);
-    Shiny.setInputValue('ruptured', true)
+    Shiny.setInputValue(opts.callback_name, true)
   }
 
   function resetTimer() {

--- a/inst/assets/rupture.js
+++ b/inst/assets/rupture.js
@@ -9,6 +9,7 @@ function watchActivity(opts) {
 
   function logout() {
     rupture(opts);
+    Shiny.setInputValue('ruptured', true)
   }
 
   function resetTimer() {


### PR DESCRIPTION
Right now sever/rupture don't actually close the session (despite the naming), this PR adds an observable input (default `ruptured`).  This allows the users to easily watch for the `rupture` event and do any clean up they need.  For example, to automatically close the session server-side instead of waiting for the timeout:

```R
observeEvent(input$ruptured, {
    session$close()
    }) 
```